### PR TITLE
docker-compose で echo を動くようにした

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,14 @@ web系ほぼ知らないので勉強しながらという感じなのでアレ�
 
 4. localhost:8080を開く
 
+### Docker でやる場合
+1. `docker-compose build` する
+
+2. `docker-compose up -d` する
+
+3. localhost:8080を開く
+
+
 ## 参考
 
 ### Go

--- a/back/.dockerignore
+++ b/back/.dockerignore
@@ -1,0 +1,1 @@
+Dockerfile

--- a/back/Dockerfile
+++ b/back/Dockerfile
@@ -1,3 +1,6 @@
+# -----
+# 1st stage: prepare unprivileged user
+# -----
 FROM golang:alpine as backend-base
 
 ENV USER "echo"
@@ -8,7 +11,9 @@ RUN addgroup "$GROUP" && adduser -D -G "$GROUP" "$USER" \
     && mkdir -p "$HOME"\
     && chown -R "$USER:$GROUP" "$HOME"
 
-
+# -----
+# 2nd stage: build executable from Go codes
+# -----
 FROM backend-base as built
 
 WORKDIR "$HOME"
@@ -18,15 +23,19 @@ COPY --chown="$USER" *.go ./
 COPY --chown="$USER" go.mod ./
 RUN go build -o backend *.go
 
-
+# -----
+# 3rd stage: set up application
+# -----
 FROM backend-base as backend
+
+ENV PORT 8080
+EXPOSE "$PORT"
 
 WORKDIR "$HOME"
 USER "$USER"
-COPY --from=built --chown="$USER" "$HOME/backend" .
+
+COPY --from=built --chown="$USER" "$HOME/backend" "$HOME/backend"
 COPY --chown="$USER" entrypoint.sh .
-COPY --chown="$USER" *.json .
 COPY --chown="$USER" echo-sns-firebase-adminsdk.json .
 
-EXPOSE 8000
 CMD ["/echo/entrypoint.sh"]

--- a/back/Dockerfile
+++ b/back/Dockerfile
@@ -1,0 +1,32 @@
+FROM golang:alpine as backend-base
+
+ENV USER "echo"
+ENV GROUP "echo"
+ENV HOME "/echo"
+
+RUN addgroup "$GROUP" && adduser -D -G "$GROUP" "$USER" \
+    && mkdir -p "$HOME"\
+    && chown -R "$USER:$GROUP" "$HOME"
+
+
+FROM backend-base as built
+
+WORKDIR "$HOME"
+USER "$USER"
+
+COPY --chown="$USER" *.go ./
+COPY --chown="$USER" go.mod ./
+RUN go build -o backend *.go
+
+
+FROM backend-base as backend
+
+WORKDIR "$HOME"
+USER "$USER"
+COPY --from=built --chown="$USER" "$HOME/backend" .
+COPY --chown="$USER" entrypoint.sh .
+COPY --chown="$USER" *.json .
+COPY --chown="$USER" echo-sns-firebase-adminsdk.json .
+
+EXPOSE 8000
+CMD ["/echo/entrypoint.sh"]

--- a/back/entrypoint.sh
+++ b/back/entrypoint.sh
@@ -1,0 +1,7 @@
+#!/bin/sh
+
+if [ -x backend ]; then
+	./backend
+else
+	go run *.go
+fi

--- a/back/entrypoint.sh
+++ b/back/entrypoint.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 
-if [ -x backend ]; then
-	./backend
+if [ -x "$HOME/backend" ]; then
+	"$HOME/backend"
 else
-	go run *.go
+	go run "*.go"
 fi

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -11,7 +11,7 @@ services:
     ports:
       - "5432:5432"
     volumes:
-      - postgres:/var/lib/postgres
+      - postgres:/var/lib/postgresql/data
     network_mode: host
 
   backend:

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -31,9 +31,9 @@ services:
   frontend:
     image: local/echo-frontend:latest
     environment:
-      HOST: 0.0.0.0
-      PORT: 8080
-      NODE_ENV: development
+      - "HOST=0.0.0.0"
+      - "PORT=8080"
+      - "NODE_ENV=development"
     build:
       context: ./front
       dockerfile: Dockerfile

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,0 +1,48 @@
+version: "3.7"
+
+services:
+  db:
+    image: postgres:latest
+    environment:
+      - "POSTGRES_PASSWORD=echo"
+      - "POSTGRES_USER=echo"
+      - "POSTGRES_DB=echo"
+    restart: always
+    ports:
+      - "5432:5432"
+    volumes:
+      - postgres:/var/lib/postgres
+    network_mode: host
+
+  backend:
+    image: local/echo-backend:latest
+    build:
+      context: ./back
+      dockerfile: Dockerfile
+    environment:
+      - "CREDENTIALS=/echo/echo-sns-firebase-adminsdk.json"
+    restart: always
+    depends_on:
+      - db
+    ports:
+      - "8000:8000"
+    network_mode: host
+
+  frontend:
+    image: local/echo-frontend:latest
+    environment:
+      HOST: 0.0.0.0
+      PORT: 8080
+      NODE_ENV: development
+    build:
+      context: ./front
+      dockerfile: Dockerfile
+    restart: always
+    depends_on:
+      - backend
+    ports:
+      - "8080:8080"
+    network_mode: host
+
+volumes:
+  postgres:

--- a/front/.dockerignore
+++ b/front/.dockerignore
@@ -1,0 +1,1 @@
+Dockerfile

--- a/front/Dockerfile
+++ b/front/Dockerfile
@@ -1,0 +1,31 @@
+FROM node:alpine as frontend-base
+
+ENV USER "echo"
+ENV GROUP "echo"
+ENV HOME "/echo"
+
+RUN addgroup "$GROUP" && adduser -D -G "$GROUP" "$USER" \
+    && mkdir -p "$HOME" \
+    && chown -R "$USER:$GROUP" "$HOME"
+
+
+FROM frontend-base as built
+WORKDIR "$HOME"
+USER "$USER"
+
+COPY --chown="$USER" package.json .
+COPY --chown="$USER" package-lock.json .
+RUN npm install
+
+
+FROM frontend-base as frontend
+
+WORKDIR "$HOME"
+USER "$USER"
+
+COPY --from=built --chown="$USER" "$HOME/node_modules" "$HOME/node_modules"
+COPY --chown="$USER" . .
+
+ENV PORT 8080
+EXPOSE "$PORT"
+CMD ["/echo/entrypoint.sh"]

--- a/front/Dockerfile
+++ b/front/Dockerfile
@@ -1,3 +1,6 @@
+# -----
+# 1st stage: prepare unprivileged user
+# -----
 FROM node:alpine as frontend-base
 
 ENV USER "echo"
@@ -8,7 +11,9 @@ RUN addgroup "$GROUP" && adduser -D -G "$GROUP" "$USER" \
     && mkdir -p "$HOME" \
     && chown -R "$USER:$GROUP" "$HOME"
 
-
+# -----
+# 2nd stage: install Node.js modules
+# -----
 FROM frontend-base as built
 WORKDIR "$HOME"
 USER "$USER"
@@ -17,8 +22,13 @@ COPY --chown="$USER" package.json .
 COPY --chown="$USER" package-lock.json .
 RUN npm install
 
-
+# -----
+# 3rd stage: set up application
+# -----
 FROM frontend-base as frontend
+
+ENV PORT 8080
+EXPOSE "$PORT"
 
 WORKDIR "$HOME"
 USER "$USER"
@@ -26,6 +36,4 @@ USER "$USER"
 COPY --from=built --chown="$USER" "$HOME/node_modules" "$HOME/node_modules"
 COPY --chown="$USER" . .
 
-ENV PORT 8080
-EXPOSE "$PORT"
 CMD ["/echo/entrypoint.sh"]

--- a/front/entrypoint.sh
+++ b/front/entrypoint.sh
@@ -1,0 +1,8 @@
+#!/bin/sh
+
+if [ "$NODE_ENV" = "development" ]; then
+	npm run dev
+elif [ "$NODE_ENV" = "production" ]; then
+	# Describe what you need for deployment in production
+	exit 0
+fi


### PR DESCRIPTION
front / back を Docker コンテナ化して PostgreSQL も Docker コンテナでまかない、`docker-compose up -d` するだけで echo が使えるようにしたい気持ちが芽生えました。
このプルリクは echo にかかる各サービスを Docker の世界で動かすようにする為のものです。

### 動かし方
以下をやった後 `http://localhost:8080` が使えるようになります：
```
$ docker-compose build
$ docker-compose up -d
```

手元の Docker 環境で動かす場合は上で事足りますが、リモート上で動かす場合は tcp:8080 と tcp:8000 との疎通がとれるようになっている必要があります。

### 備考
各サービスの localhost 依存をなくしたかったが修正範囲がでかくなりそうだったのでやめました。
